### PR TITLE
Add IShape area tests

### DIFF
--- a/Appegy.Union.Generator~/Appegy.Union.Generator.Tests/Shapes/ShapeInterfaceAreaTests.cs
+++ b/Appegy.Union.Generator~/Appegy.Union.Generator.Tests/Shapes/ShapeInterfaceAreaTests.cs
@@ -1,0 +1,53 @@
+using Appegy.Union.Generator.Shapes;
+using NUnit.Framework;
+
+namespace Appegy.Union.Generator.Tests.Shapes;
+
+[TestFixture]
+public class ShapeInterfaceAreaTests
+{
+    [Test]
+    public void WhenAccessingAreaViaInterface_AndTypeIsCircle_ThenReturnsCircleArea()
+    {
+        // Arrange
+        var circle = new Circle(5);
+        var union = new Shape(circle);
+        IShape shape = union;
+
+        // Act
+        var area = shape.Area;
+
+        // Assert
+        Assert.AreEqual(circle.Area, area);
+    }
+
+    [Test]
+    public void WhenAccessingAreaViaInterface_AndTypeIsRectangle_ThenReturnsRectangleArea()
+    {
+        // Arrange
+        var rectangle = new Rectangle(4, 6);
+        var union = new Shape(rectangle);
+        IShape shape = union;
+
+        // Act
+        var area = shape.Area;
+
+        // Assert
+        Assert.AreEqual(rectangle.Area, area);
+    }
+
+    [Test]
+    public void WhenAccessingAreaViaInterface_AndTypeIsHexagon_ThenReturnsHexagonArea()
+    {
+        // Arrange
+        var hexagon = new Hexagon(3);
+        var union = new Shape(hexagon);
+        IShape shape = union;
+
+        // Act
+        var area = shape.Area;
+
+        // Assert
+        Assert.AreEqual(hexagon.Area, area);
+    }
+}


### PR DESCRIPTION
## Summary
- add new unit tests verifying `Area` via the `IShape` interface
- rename the interface variable to `shape`
- rename unionShape variable to union

## Testing
- `dotnet test Appegy.Union.Generator~/Appegy.Union.Generator.Tests/Appegy.Union.Generator.Tests.csproj -v minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840096cbbcc83258b275fd86aeb3fc0